### PR TITLE
增加文本对象参数

### DIFF
--- a/packages/core/__tests__/lib/core-check.test.ts
+++ b/packages/core/__tests__/lib/core-check.test.ts
@@ -201,6 +201,7 @@ describe('@idraw/core static check', () => {
         bgColor: '#f0f0f0',
         fontSize: 12,
         lineHeight: 12,
+        lineSpacing: 0,
         fontWeight: 'bold',
         fontFamily: 'abc',
         textAlign: 'center',

--- a/packages/core/__tests__/lib/core-is.test.ts
+++ b/packages/core/__tests__/lib/core-is.test.ts
@@ -150,6 +150,12 @@ describe('@idraw/core:static is', () => {
     expect(Core.is.lineHeight(-10)).toStrictEqual(false);
   });
 
+  test('Core.is.lineSpacing', () => {
+    expect(Core.is.lineSpacing(12)).toStrictEqual(true);
+    expect(Core.is.lineSpacing(0)).toStrictEqual(false);
+    expect(Core.is.lineSpacing(-10)).toStrictEqual(false);
+  });
+
   test('Core.is.textAlign', () => {
     expect(Core.is.textAlign('center')).toStrictEqual(true);
     expect(Core.is.textAlign('left')).toStrictEqual(true);

--- a/packages/core/src/lib/check.ts
+++ b/packages/core/src/lib/check.ts
@@ -81,6 +81,7 @@ function textDesc(desc: any): boolean {
     color,
     fontSize,
     lineHeight,
+    lineSpacing,
     fontFamily,
     textAlign,
     fontWeight,
@@ -104,6 +105,9 @@ function textDesc(desc: any): boolean {
     return false;
   }
   if (desc.hasOwnProperty('lineHeight') && !is.lineHeight(lineHeight)) {
+    return false;
+  }
+  if (desc.hasOwnProperty('lineSpacing') && !is.lineSpacing(lineSpacing)) {
     return false;
   }
   if (desc.hasOwnProperty('fontFamily') && !is.fontFamily(fontFamily)) {

--- a/packages/core/src/lib/is.ts
+++ b/packages/core/src/lib/is.ts
@@ -84,6 +84,10 @@ function lineHeight(value: any) {
   return number(value) && value > 0;
 }
 
+function lineSpacing(value: any) {
+  return number(value) && value > 0;
+}
+
 function strokeWidth(value: any) {
   return number(value) && value > 0;
 }
@@ -118,6 +122,7 @@ const is: IsTypeUtil = {
   text,
   fontSize,
   lineHeight,
+  lineSpacing,
   textAlign,
   fontFamily,
   fontWeight,
@@ -143,6 +148,7 @@ type IsTypeUtil = {
   fontSize: (value: any) => boolean;
   fontWeight: (value: any) => boolean;
   lineHeight: (value: any) => boolean;
+  lineSpacing: (value: any) => boolean;
   textAlign: (value: any) => boolean;
   fontFamily: (value: any) => boolean;
   strokeWidth: (value: any) => boolean;

--- a/packages/renderer/src/lib/draw/text.ts
+++ b/packages/renderer/src/lib/draw/text.ts
@@ -31,6 +31,7 @@ export function drawText(
     const fontHeight = desc.lineHeight || desc.fontSize;
     const descTextList = descText.split('\n');
     const lines: { text: string; width: number }[] = [];
+    const lineSpacing = desc.lineSpacing || 0;
 
     let lineNum = 0;
     descTextList.forEach((tempText: string, idx: number) => {
@@ -84,40 +85,31 @@ export function drawText(
     });
 
     let startY = 0;
-    if (lines.length * fontHeight < elem.h) {
+    if (lines.length * fontHeight + (lines.length > 1 ? (lines.length - 1) * lineSpacing : 0) < elem.h) {
       if (elem.desc.verticalAlign === 'top') {
         startY = 0;
       } else if (elem.desc.verticalAlign === 'bottom') {
-        startY += elem.h - lines.length * fontHeight;
+        startY += elem.h - lines.length * fontHeight - (lines.length > 1 ? (lines.length - 1) * lineSpacing : 0);
       } else {
         // middle and default
-        startY += (elem.h - lines.length * fontHeight) / 2;
+        startY += (elem.h - lines.length * fontHeight - (lines.length > 1 ? (lines.length - 1) * lineSpacing : 0)) / 2;
       }
     }
 
     // draw text lines
     {
       const _y = elem.y + startY;
-      if (
-        desc.textShadowColor !== undefined &&
-        isColorStr(desc.textShadowColor)
-      ) {
-        ctx.setShadowColor(desc.textShadowColor);
+      if (desc.textShadowColor !== undefined && isColorStr(desc.textShadowColor)) {
+        ctx.shadowColor = desc.textShadowColor;
       }
-      if (
-        desc.textShadowOffsetX !== undefined &&
-        is.number(desc.textShadowOffsetX)
-      ) {
-        ctx.setShadowOffsetX(desc.textShadowOffsetX);
+      if (desc.textShadowOffsetX !== undefined && is.number(desc.textShadowOffsetX)) {
+        ctx.shadowOffsetX = desc.textShadowOffsetX;
       }
-      if (
-        desc.textShadowOffsetY !== undefined &&
-        is.number(desc.textShadowOffsetY)
-      ) {
-        ctx.setShadowOffsetY(desc.textShadowOffsetY);
+      if (desc.textShadowOffsetY !== undefined && is.number(desc.textShadowOffsetY)) {
+        ctx.shadowOffsetY = desc.textShadowOffsetY;
       }
       if (desc.textShadowBlur !== undefined && is.number(desc.textShadowBlur)) {
-        ctx.setShadowBlur(desc.textShadowBlur);
+        ctx.shadowBlur = desc.textShadowBlur;
       }
       lines.forEach((line, i) => {
         let _x = elem.x;
@@ -126,32 +118,7 @@ export function drawText(
         } else if (desc.textAlign === 'right') {
           _x = elem.x + (elem.w - line.width);
         }
-        ctx.fillText(line.text, _x, _y + fontHeight * i);
-      });
-      clearContext(ctx);
-    }
-
-    // draw text stroke
-    if (
-      isColorStr(desc.strokeColor) &&
-      desc.strokeWidth !== undefined &&
-      desc.strokeWidth > 0
-    ) {
-      const _y = elem.y + startY;
-      lines.forEach((line, i) => {
-        let _x = elem.x;
-        if (desc.textAlign === 'center') {
-          _x = elem.x + (elem.w - line.width) / 2;
-        } else if (desc.textAlign === 'right') {
-          _x = elem.x + (elem.w - line.width);
-        }
-        if (desc.strokeColor !== undefined) {
-          ctx.setStrokeStyle(desc.strokeColor);
-        }
-        if (desc.strokeWidth !== undefined && desc.strokeWidth > 0) {
-          ctx.setLineWidth(desc.strokeWidth);
-        }
-        ctx.strokeText(line.text, _x, _y + fontHeight * i);
+        ctx.fillText(line.text, _x, _y + fontHeight * i + i * lineSpacing);
       });
     }
   });

--- a/packages/renderer/src/lib/draw/text.ts
+++ b/packages/renderer/src/lib/draw/text.ts
@@ -43,6 +43,14 @@ export function drawText(
             ctx.calcDeviceNum(elem.w)
           ) {
             lineText += tempText[i] || '';
+          } else if (ctx.measureText(lineText + (tempText[i] || '')).width == ctx.calcDeviceNum(elem.w)) {
+            lineText += tempText[i] || '';
+            lines.push({
+              text: lineText,
+              width: ctx.calcScreenNum(ctx.measureText(lineText).width)
+            });
+            lineText = '';
+            lineNum++;
           } else {
             lines.push({
               text: lineText,

--- a/packages/types/src/lib/common.ts
+++ b/packages/types/src/lib/common.ts
@@ -17,6 +17,7 @@ type IsTypeUtil = {
   fontSize: (value: any) => boolean;
   fontWeight: (value: any) => boolean;
   lineHeight: (value: any) => boolean;
+  lineSpacing: (value: any) => boolean;
   textAlign: (value: any) => boolean;
   fontFamily: (value: any) => boolean;
   strokeWidth: (value: any) => boolean;

--- a/packages/types/src/lib/element.ts
+++ b/packages/types/src/lib/element.ts
@@ -72,6 +72,7 @@ type DataElemDescText = {
   color: string;
   fontSize: number;
   lineHeight?: number;
+  lineSpacing?: number;
   fontWeight?: 'bold' | '';
   fontFamily?: string;
   textAlign?: 'center' | 'left' | 'right';

--- a/packages/util/src/lib/check.ts
+++ b/packages/util/src/lib/check.ts
@@ -81,6 +81,7 @@ function textDesc(desc: any): boolean {
     color,
     fontSize,
     lineHeight,
+    lineSpacing,
     fontFamily,
     textAlign,
     fontWeight,
@@ -104,6 +105,9 @@ function textDesc(desc: any): boolean {
     return false;
   }
   if (desc.hasOwnProperty('lineHeight') && !is.lineHeight(lineHeight)) {
+    return false;
+  }
+  if (desc.hasOwnProperty('lineSpacing') && !is.lineSpacing(lineSpacing)) {
     return false;
   }
   if (desc.hasOwnProperty('fontFamily') && !is.fontFamily(fontFamily)) {

--- a/packages/util/src/lib/is.ts
+++ b/packages/util/src/lib/is.ts
@@ -77,6 +77,10 @@ function lineHeight(value: any) {
   return number(value) && value > 0;
 }
 
+function lineSpacing(value: any) {
+  return number(value) && value > 0;
+}
+
 function strokeWidth(value: any) {
   return number(value) && value > 0;
 }
@@ -97,7 +101,7 @@ const is = {
   x, y, w, h, angle, number,
   borderWidth, borderRadius, color,
   imageSrc, imageURL, imageBase64, svg, html,
-  text, fontSize, lineHeight, textAlign, fontFamily, fontWeight,
+  text, fontSize, lineHeight, lineSpacing textAlign, fontFamily, fontWeight,
   strokeWidth,
 };
 


### PR DESCRIPTION
@chenshenhai 作者你好，我发现0.4版本中似乎有些函数和监听事件方法并不全支持0.3版本，希望能够在0.3版本中修复#303问题，并对文本对象扩充行间距参数。
![image](https://github.com/idrawjs/idraw/assets/70926594/31a90d16-ca5a-42ef-920a-08f98fca36cf)
本地测试效果如下：
![image](https://github.com/idrawjs/idraw/assets/70926594/1e9b608e-f52c-4a6e-b9ca-e12dea5f5aff)
我本地修改测试的idraw版本为0.3.0-alpha.6，我将0.4版本中的文本绘制方法复制到了0.3版本中，并将参数改为了0.3版本的参数。